### PR TITLE
Explicitly set the compiler for zlib to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ add_subdirectory(libraries/zlib ${CMAKE_CURRENT_BINARY_DIR}/zlib_build)
 target_link_libraries(${PROJECT_NAME} PUBLIC zlibstatic)
 set_property(TARGET zlibstatic PROPERTY FOLDER "External/zlib")
 set_property(TARGET zlib PROPERTY FOLDER "External/zlib")
+set_property(TARGET zlibstatic PROPERTY CXX_STANDARD 20)
+set_property(TARGET zlib PROPERTY CXX_STANDARD 20)
+
 # blosc
 set(BUILD_TESTS OFF CACHE BOOL "")
 set(BUILD_SHARED OFF CACHE BOOL "")


### PR DESCRIPTION
In MacOS the zlib defaults to a C99 compiler, which breaks at a few parts instances.
This forces CMake to choose a C++20 compile target, which is the default of the project.