### PR TITLE
Fix most compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.15)
 
 project(easyVDB VERSION 1.0.0 LANGUAGES CXX)
 
@@ -45,10 +45,10 @@ set(BUILD_TESTS OFF CACHE BOOL "")
 set(BUILD_SHARED OFF CACHE BOOL "")
 set(BUILD_FUZZERS OFF CACHE BOOL "")
 set(BUILD_BENCHMARKS OFF CACHE BOOL "")
-set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 add_subdirectory(libraries/c-blosc)
 target_link_libraries(${PROJECT_NAME} PUBLIC blosc_static)
 set_property(TARGET blosc_static PROPERTY FOLDER "External/blosc")
+target_compile_options(blosc_static PRIVATE "-w") # ignore blosc compiler warnings
 
 # glm
 if (NOT TARGET glm)

--- a/src/bufferIterator.cpp
+++ b/src/bufferIterator.cpp
@@ -87,6 +87,9 @@ long long BufferIterator::readInt(unsigned int precision)
 
 		return val;
 	}
+
+	assert(0);
+	return 0;
 }
 
 float BufferIterator::readFloat(unsigned int precision)
@@ -108,24 +111,24 @@ float BufferIterator::readFloat(unsigned int precision)
 
 		std::string binary = "";
 		for (unsigned int i = 0u; i < precisionLUT.size; i++) {
-			unsigned int bin = readBytes(charSize);
+			unsigned int bin = static_cast<unsigned int>(readBytes(charSize));
 			std::string s = std::bitset< 8 >(bin).to_string();
 			binary = s + binary;
 		}
 
 		// NOTE https://stackoverflow.com/questions/37022434/how-do-i-parse-a-twos-complement-string-to-a-number
 		// also this https://stackoverflow.com/questions/29931827/stoi-causes-out-of-range-error
-		return (int)~~std::stoll(binary, nullptr, 2);
+		return static_cast<float>((int)~~std::stoll(binary, nullptr, 2));
 	}
 	else if (precision == halfFloatType)
 	{
-		unsigned short raw = readBytes(charSize);
+		unsigned short raw = static_cast<unsigned short>(readBytes(charSize));
 		raw |= static_cast<unsigned short>(readBytes(charSize)) << 8;
 		return half_to_float(raw);
 	}
 	else if (precision == floatType)
 	{
-		unsigned int raw = readBytes(charSize);
+		unsigned int raw = static_cast<unsigned int>(readBytes(charSize));
 		raw |= static_cast<unsigned short>(readBytes(charSize)) << 8;
 		raw |= static_cast<unsigned short>(readBytes(charSize)) << 16;
 		raw |= static_cast<unsigned short>(readBytes(charSize)) << 24;
@@ -150,7 +153,7 @@ float BufferIterator::readFloat(unsigned int precision)
 
 		std::string binary = "";
 		for (unsigned int i = 0u; i < precisionLUT.size; i++) {
-			unsigned int bin = readBytes(charSize);
+			unsigned int bin = static_cast<unsigned int>(readBytes(charSize));
 			std::string s = std::bitset< 8 >(bin).to_string();
 			binary = s + binary;
 		}
@@ -182,23 +185,26 @@ float BufferIterator::readFloat(unsigned int precision)
 		{
 			v2_seglist.push_back(aux3_v2_string);
 		}
-		int v2_len = (v2_seglist.size() > 1 ? v2_seglist[1] : std::string("")).size();
+		size_t v2_len = (v2_seglist.size() > 1 ? v2_seglist[1] : std::string("")).size();
 		double v2_len_p2 = pow(2, v2_len);
-		double v2_toNumber = std::stoll(aux2_v2_string, nullptr, 2);
-		double v2 = v2_toNumber / v2_len_p2;
+		long long v2_toNumber = std::stoll(aux2_v2_string, nullptr, 2);
+		double v2 = static_cast<double>(v2_toNumber) / v2_len_p2;
 		//
 
 		if (v1 == 0 && v2 == 0) {
 			return 0;
 		}
 
-		return sign * (v1 + v2);
+		return static_cast<float>(sign * (v1 + v2));
 	}
+
+	assert(0);
+	return 0.0f;
 }
 
 std::string BufferIterator::readString(unsigned int castTo)
 {
-	unsigned int nameSize = readBytes(uint32Size);
+	unsigned int nameSize = static_cast<unsigned int>(readBytes(uint32Size));
 	std::string name = "";
 
 	if (castTo == int64Type) {
@@ -227,7 +233,7 @@ std::string BufferIterator::readString(unsigned int castTo)
 	}
 	else {
 		for (unsigned int i = 0; i < nameSize; i++) {
-			name += readBytes(charSize);
+			name += static_cast<char>((readBytes(charSize)));
 		}
 	}
 
@@ -236,7 +242,7 @@ std::string BufferIterator::readString(unsigned int castTo)
 
 std::string BufferIterator::readString(std::string castTo)
 {
-	unsigned int nameSize = readBytes(uint32Size);
+	unsigned int nameSize = static_cast<unsigned int>(readBytes(uint32Size));
 	std::string name = "";
 
 	if (castTo == getPrecisionString(int32Type)) {
@@ -268,7 +274,7 @@ std::string BufferIterator::readString(std::string castTo)
 	}
 	else {
 		for (unsigned int i = 0; i < nameSize; i++) {
-			name += readBytes(charSize);
+			name += static_cast<char>(readBytes(charSize));
 		}
 	}
 

--- a/src/bufferIterator.h
+++ b/src/bufferIterator.h
@@ -77,7 +77,7 @@ namespace easyVDB
 	public:
 		// buffer data management
 		std::vector<uint8_t>& rawBuffer;
-		unsigned int offset;
+		unsigned int offset = 0;
 
 		BufferIterator(std::vector<uint8_t>& source, unsigned int offset = 0u);
 
@@ -95,10 +95,10 @@ namespace easyVDB
 	};
 
 	struct Compression {
-		bool none;
-		bool zlib;
-		bool activeMask;
-		bool blosc;
+		bool none = false;
+		bool zlib = false;
+		bool activeMask = false;
+		bool blosc = false;
 	};
 
 	struct DelayedLoadMetadata {
@@ -112,11 +112,11 @@ namespace easyVDB
 	struct SharedContext {
 		Compression compression;
 		Precision valueType;
-		bool useHalf;
-		bool useDelayedLoadMeta;
+		bool useHalf = false;
+		bool useDelayedLoadMeta = false;
 		DelayedLoadMetadata delayedMetada;
-		BufferIterator* bufferIterator;
-		unsigned int* version;
+		BufferIterator* bufferIterator = nullptr;
+		unsigned int* version = nullptr;
 	};
 
 	struct Metadata {

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -23,7 +23,7 @@ void Grid::read()
 	readHeader();
 
 	if (gridBufferPosition != sharedContext->bufferIterator->offset) {
-		sharedContext->bufferIterator->offset = gridBufferPosition; // seek to grid
+		sharedContext->bufferIterator->offset = static_cast<unsigned int>(gridBufferPosition); // seek to grid
 	}
 
 	// Read grid interval
@@ -49,7 +49,7 @@ void Grid::read()
 	}
 
 	// Hack to make multi - grid VDBs work without reading leaf values
-	sharedContext->bufferIterator->offset = endBufferPosition;
+	sharedContext->bufferIterator->offset = static_cast<unsigned int>(endBufferPosition);
 }
 
 void Grid::readHeader()
@@ -60,7 +60,7 @@ void Grid::readHeader()
 	if (gridType.find(halfFloatGridPrefix) != -1) {
 		// TODO in case it contains half floats
 		saveAsHalfFloat = true;
-		char* ptr;
+		//char* ptr;
 		//ptr = strtok((char*)gridType.data(), halfFloatGridPrefix.data());
 		//gridType = gridType.split(halfFloatGridPrefix).join("");
 	}
@@ -83,7 +83,7 @@ void Grid::readHeader()
 void Grid::readCompression()
 {
 	if (*(sharedContext->version) >= OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
-		unsigned int compress = sharedContext->bufferIterator->readBytes(uint32Size);
+		unsigned int compress = static_cast<unsigned int>(sharedContext->bufferIterator->readBytes(uint32Size));
 		sharedContext->compression.none = compress & 0x0;
 		sharedContext->compression.zlib = compress & 0x1;
 		sharedContext->compression.activeMask = compress & 0x2;
@@ -97,8 +97,8 @@ void Grid::readCompression()
 
 void Grid::readMetadata()
 {
-	unsigned int metadataSize = sharedContext->bufferIterator->readBytes(uint32Size);	// 4 bytes (we will have 11 entries)
-	for (int i = 0; i < metadataSize; i++) {
+	unsigned int metadataSize = static_cast<unsigned int>(sharedContext->bufferIterator->readBytes(uint32Size));	// 4 bytes (we will have 11 entries)
+	for (unsigned int i = 0; i < metadataSize; i++) {
 		std::string name = sharedContext->bufferIterator->readString();					// 9 + 17 + 17 + 20 + 21 + 18 + 20 + 26 + 8 + 19 + 12 = 187 bytes
 		std::string type = sharedContext->bufferIterator->readString();					// 10 + 9 + 9 + 10 + 17 + 9 + 9 + 8 + 10 + 9 + 9 = 109 bytes
 		std::string value = sharedContext->bufferIterator->readString(type);			// 11 + 16 + 16 + 25 + 43151 + 12 + 12 + 5 + 11 + 8 + 8 = 43275 bytes
@@ -114,7 +114,7 @@ void Grid::readMetadata()
 
 	// todo check
 	if (*(sharedContext->version) < 219u) {
-		for (int i = 0; i < metadataSize; i++) {
+		for (unsigned int i = 0; i < metadataSize; i++) {
 			if (metadata[i].name == "name")
 				metadata[i].value = gridName;
 		}
@@ -172,7 +172,7 @@ void Grid::readTopology() // in implosion vdb here we are in offset 43885
 	sharedContext->useHalf = saveAsHalfFloat;
 	sharedContext->valueType = getGridValueType();
 
-	unsigned int topologyBufferCount = sharedContext->bufferIterator->readBytes(uint32Size); // 4 bytes
+	unsigned int topologyBufferCount = static_cast<unsigned int>(sharedContext->bufferIterator->readBytes(uint32Size)); // 4 bytes
 	if (topologyBufferCount != 1) {
 		// NOTE https://github.com/AcademySoftwareFoundation/openvdb/blob/master/openvdb/openvdb/tree/Tree.h#L1120
 		std::cout << "[WARN] Unsupported: Multi-buffer trees" << std::endl;

--- a/src/grid.h
+++ b/src/grid.h
@@ -61,7 +61,6 @@ namespace easyVDB
 		};
 
 		void applyInverseTransformMap(glm::vec3& vector) {
-			glm::vec3 result;
 			if (this->mapType == uniformScaleTranslateMap || this->mapType == scaleTranslateMap) {
 				vector = vector * this->scaleInverse;
 			}
@@ -93,9 +92,9 @@ namespace easyVDB
 
 	class Grid {
 	public:
-		SharedContext* sharedContext;
+		SharedContext* sharedContext = nullptr;
 
-		Accessor* accessor;
+		Accessor* accessor = nullptr;
 
 		std::string halfFloatGridPrefix = "_HalfFloat";
 
@@ -108,14 +107,14 @@ namespace easyVDB
 		std::string gridName;
 		std::string gridType;
 
-		long long gridBufferPosition;
-		long long blockBufferPosition;
-		long long endBufferPosition;
+		long long gridBufferPosition = 0;
+		long long blockBufferPosition = 0;
+		long long endBufferPosition = 0;
 
 		//Compression compression;
 		std::vector<Metadata> metadata;
 
-		VDB_Transform* transform;
+		VDB_Transform* transform = nullptr;
 
 		RootNode root;
 

--- a/src/mask.cpp
+++ b/src/mask.cpp
@@ -36,11 +36,11 @@ void Mask::read(InternalNode* node)
 
 	int dim = 1 << targetNode->log2dim;
 	this->size = 1 << (3 * targetNode->log2dim);
-	int wordCount = this->size >> 6;
+	unsigned int wordCount = this->size >> 6;
 
 	onIndexCache.resize(wordCount * 64);
 	for (unsigned int i = 0; i < wordCount * 64; i += 8) {
-		unsigned int byte = targetNode->sharedContext->bufferIterator->readBytes(1);
+		unsigned int byte = static_cast<unsigned int>(targetNode->sharedContext->bufferIterator->readBytes(1));
 		// reverse and "push" to onIndexCache mask 
 		for (unsigned int k = 0; k < 8; k++) {
 			onIndexCache[i+k] = (byte & 0x01);
@@ -62,8 +62,8 @@ int Mask::countOn()
 		return onCache;
 	}
 
-	unsigned int count = 0;
-	count = std::count(onIndexCache.begin(), onIndexCache.end(), true);
+	int count = 0;
+	count = static_cast<int>(std::count(onIndexCache.begin(), onIndexCache.end(), 1));
 
 	return count;
 }

--- a/src/mask.h
+++ b/src/mask.h
@@ -12,11 +12,11 @@ namespace easyVDB
 	class Mask {
 	public:
 
-		InternalNode* targetNode;
+		InternalNode* targetNode = nullptr;
 
-		int size;
-		int onCache;
-		int offCache;
+		int size = 0;
+		int onCache = 0;
+		int offCache = 0;
 
 		std::vector<std::string> words;
 		std::vector<uint8_t> onIndexCache; // this is a bool list

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -20,8 +20,8 @@ RootNode::RootNode()
 void RootNode::read()
 {
 	background = sharedContext->bufferIterator->readFloat(floatType); // always read background as float, even if the data is stored as half floats
-	numTiles = sharedContext->bufferIterator->readBytes(uint32Size);
-	numChildren = sharedContext->bufferIterator->readBytes(uint32Size);
+	numTiles = static_cast<unsigned int>(sharedContext->bufferIterator->readBytes(uint32Size));
+	numChildren = static_cast<unsigned int>(sharedContext->bufferIterator->readBytes(uint32Size));
 	// init table
 	origin = glm::vec3(0.0f);
 
@@ -79,7 +79,7 @@ float RootNode::getValue(glm::ivec3 pos, Accessor* accessor)
 {
 	float max = 0.0;
 
-	for (unsigned int i = 0; i < this->table.size(); i++) {
+	for (size_t i = 0; i < this->table.size(); i++) {
 		max = std::max(max, this->table[i].getValue(pos, accessor));
 
 		if (max != 0.0) {
@@ -189,9 +189,9 @@ void InternalNode::readTopology(unsigned int _id, glm::vec3 _origin, float _back
 				child->parent = this;
 				child->readTopology(offset, vec, background, depth + 1);
 
-				child->origin.x = (int)vec.x << child->total;
-				child->origin.y = (int)vec.y << child->total;
-				child->origin.z = (int)vec.z << child->total;
+				child->origin.x = static_cast<float>((int)vec.x << child->total);
+				child->origin.y = static_cast<float>((int)vec.y << child->total);
+				child->origin.z = static_cast<float>((int)vec.z << child->total);
 
 				this->table[offset] = child;
 				this->leavesCount += child->leavesCount;
@@ -246,7 +246,7 @@ ErrorCode InternalNode::readValues(std::vector<float>& destBuffer, int destCount
 			this->sharedContext->bufferIterator->readBytes(1u);
 		}
 		else {
-			metadata = this->sharedContext->bufferIterator->readBytes(1u); // read 1 byte
+			metadata = static_cast<unsigned int>(this->sharedContext->bufferIterator->readBytes(1u)); // read 1 byte
 		}
 	}
 
@@ -336,7 +336,7 @@ ErrorCode InternalNode::readData(unsigned int tempCount, std::vector<float>& out
 		// size_t compressedSize = metadata->getCompressedSize(metadataOffset);
 		int64_t compressedSize = mCompressedSize[this->sharedContext->delayedMetada.leafIndex];
 
-		sharedContext->bufferIterator->readBytes(compressedSize); // skip compressedSize bytes
+		sharedContext->bufferIterator->readBytes(static_cast<unsigned int>(compressedSize)); // skip compressedSize bytes
 	}
 	else if (this->sharedContext->compression.blosc) {
 		return readCompressedData("blosc", outArray);
@@ -363,18 +363,18 @@ ErrorCode InternalNode::readCompressedData(std::string codec, std::vector<float>
 
 		if (sharedContext->useHalf)
 		{
-			for (int i = 0; i < -compressedBytesCount; i += s) {
+			for (long long i = 0; i < -compressedBytesCount; i += s) {
 				outArray[i] = sharedContext->bufferIterator->readFloat(getPrecisionIdx("half"));
 			}
 		}
 		else {
-			for (int i = 0; i < -compressedBytesCount; i += s) {
+			for (long long i = 0; i < -compressedBytesCount; i += s) {
 				outArray[i] = sharedContext->bufferIterator->readFloat(sharedContext->valueType);
 			}
 		}
 	}
 	else {
-		uint8_t* compressedBytes = sharedContext->bufferIterator->readRawBytes(compressedBytesCount);
+		uint8_t* compressedBytes = sharedContext->bufferIterator->readRawBytes(static_cast<unsigned int>(compressedBytesCount));
 		uint8_t* decompressedBytes{ 0 };
 
 		int valueTypeLength = sharedContext->bufferIterator->floatingPointPrecisionLUT(sharedContext->valueType).size;

--- a/src/node.h
+++ b/src/node.h
@@ -15,30 +15,30 @@ namespace easyVDB
 
 	class InternalNode {
 	public:
-		SharedContext* sharedContext;
+		SharedContext* sharedContext = nullptr;
 
 		unsigned int log2dimMap[3] = { 5, 4, 3 };
 		unsigned int totalMap[3] = { 4, 3, 0 };
 		std::string nodeTypeMap[3] = { "internal", "internal", "leaf" };
 
-		unsigned int leavesCount;
+		unsigned int leavesCount = 0;
 
-		unsigned int depth;
-		unsigned int id;
-		glm::vec3 origin;
-		float background;
-		int total;
-		unsigned int dim;
-		int offsetMask;
+		unsigned int depth = 0;
+		unsigned int id = 0;
+		glm::vec3 origin = {};
+		float background = 0.0f;
+		int total = 0;
+		unsigned int dim = 0;
+		int offsetMask = 0;
 
-		unsigned int log2dim;
-		int numValues;
+		unsigned int log2dim = 0;
+		int numValues = 0;
 
-		bool bboxInitialized;
+		bool bboxInitialized = 0;
 		Bbox localBbox;
 
-		bool oldVersion;
-		bool useCompression;
+		bool oldVersion = false;
+		bool useCompression = false;
 
 		std::vector<InternalNode*> table;
 
@@ -49,8 +49,8 @@ namespace easyVDB
 		std::vector<float> values; // node 5-4
 		std::vector<float> data; // node 3
 
-		InternalNode* parent;
-		InternalNode* firstChild;
+		InternalNode* parent = nullptr;
+		InternalNode* firstChild = nullptr;
 
 		InternalNode();
 
@@ -69,13 +69,13 @@ namespace easyVDB
 
 	class RootNode {
 	public:
-		SharedContext* sharedContext;
+		SharedContext* sharedContext = nullptr;
 
-		unsigned int leavesCount;
+		unsigned int leavesCount = 0;
 
-		float background;
-		unsigned int numTiles;
-		unsigned int numChildren;
+		float background = 0.0f;
+		unsigned int numTiles = 0;
+		unsigned int numChildren = 0;
 		glm::vec3 origin;
 
 		std::vector<InternalNode> table; // ?

--- a/src/openvdbReader.cpp
+++ b/src/openvdbReader.cpp
@@ -109,13 +109,13 @@ bool OpenVDBReader::read(std::string file_path)
 
 bool OpenVDBReader::isValidFile()
 {
-	unsigned int magic = bufferIterator->readBytes(uint64Size);
+	long long magic = bufferIterator->readBytes(uint64Size);
 	return 0x56444220 == magic;
 }
 
 bool OpenVDBReader::readFileVersion()
 {
-	fileVersion.version = bufferIterator->readBytes(uint32Size);
+	fileVersion.version = static_cast<unsigned int>(bufferIterator->readBytes(uint32Size));
 
 	if (fileVersion.version < OPENVDB_MIN_SUPPORTED_VERSION) {
 		std::cout << "[INFO] Version '" << fileVersion.version << "' is not supported. The oldest supported version is the '" << OPENVDB_MIN_SUPPORTED_VERSION << "'" << std::endl;
@@ -123,8 +123,8 @@ bool OpenVDBReader::readFileVersion()
 	}
 
 	// Stored from 211 onward, our minimum supported version is 213
-	fileVersion.major = bufferIterator->readBytes(uint32Size);
-	fileVersion.minor = bufferIterator->readBytes(uint32Size);
+	fileVersion.major = static_cast<unsigned int>(bufferIterator->readBytes(uint32Size));
+	fileVersion.minor = static_cast<unsigned int>(bufferIterator->readBytes(uint32Size));
 	
 	return true;
 }
@@ -135,7 +135,7 @@ bool OpenVDBReader::readHeader()
 	hasGridOffsets = bufferIterator->readBytes(charSize);
 
 	if (fileVersion.version >= OPENVDB_FILE_VERSION_SELECTIVE_COMPRESSION && fileVersion.version < OPENVDB_FILE_VERSION_NODE_MASK_COMPRESSION) {
-		unsigned int compress = bufferIterator->readBytes(charSize);
+		unsigned char compress = static_cast<unsigned char>(bufferIterator->readBytes(charSize));
 		compression.none = compress & 0x0;
 		compression.zlib = compress & 0x1;
 		compression.activeMask = compress & 0x2;
@@ -153,11 +153,11 @@ bool OpenVDBReader::readHeader()
 	// The extra 4 bytes are for the hyphens (-)
 	std::string uuid = "";
 	for (int i = 0; i < 36; i++) {
-		uuid += bufferIterator->readBytes(1);
+		uuid += static_cast<char>(bufferIterator->readBytes(1));
 	}
 
-	unsigned int metadataSize = bufferIterator->readBytes(uint32Size);
-	for (int i = 0; i < metadataSize; i++) {
+	unsigned int metadataSize = static_cast<unsigned int>(bufferIterator->readBytes(uint32Size));
+	for (unsigned int i = 0; i < metadataSize; i++) {
 		std::string name = bufferIterator->readString();
 		std::string type = bufferIterator->readString();
 		std::string value = bufferIterator->readString(type);
@@ -176,7 +176,7 @@ bool OpenVDBReader::readGrids()
 		std::cout << "[WARN] Unsupported: VDB without grid offsets" << std::endl;
 	}
 	else {
-		unsigned int gridCount = bufferIterator->readBytes(uint32Size);
+		unsigned int gridCount = static_cast<unsigned int>(bufferIterator->readBytes(uint32Size));
 		gridsSize = gridCount;
 		grids = new Grid[gridCount];
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -38,13 +38,13 @@ namespace easyVDB
         for (int i = 0; i < hex.length(); i++) {
             if (hex[i] >= 48 && hex[i] <= 57)
             {
-                result += (hex[i] - 48) * pow(16, hex.length() - i - 1);
+                result += (hex[i] - 48) * static_cast<long long>(pow(16, hex.length() - i - 1));
             }
             else if (hex[i] >= 65 && hex[i] <= 70) {
-                result += (hex[i] - 55) * pow(16, hex.length() - i - 1);
+                result += (hex[i] - 55) * static_cast<long long>(pow(16, hex.length() - i - 1));
             }
             else if (hex[i] >= 97 && hex[i] <= 102) {
-                result += (hex[i] - 87) * pow(16, hex.length() - i - 1);
+                result += (hex[i] - 87) * static_cast<long long>(pow(16, hex.length() - i - 1));
             }
         }
         return result;


### PR DESCRIPTION
There were many compiler warnings, mainly from implicit casts and uninitialized variables. I've tested loading a couple of .vdb samples and results in the same rendering.

Also, update blosc to last commit to fix CMake build error, it's a better fix than what I did in the last commit.